### PR TITLE
Replace "/reform/re-form" With "/re-form" in a Fancy, Regexy, Way

### DIFF
--- a/apps/www/__registry__/icons.tsx
+++ b/apps/www/__registry__/icons.tsx
@@ -4,264 +4,448 @@
 import * as React from "react"
 
 export const Icons = {
-  "AlertCircle": {
-  lucide: React.lazy(() => import("lucide-react").then(mod => ({
-    default: mod.AlertCircle
-  }))),
-  radix: React.lazy(() => import("@radix-ui/react-icons").then(mod => ({
-    default: mod.ExclamationTriangleIcon
-  }))),
-},  "ArrowLeft": {
-  lucide: React.lazy(() => import("lucide-react").then(mod => ({
-    default: mod.ArrowLeft
-  }))),
-  radix: React.lazy(() => import("@radix-ui/react-icons").then(mod => ({
-    default: mod.ArrowLeftIcon
-  }))),
-},  "ArrowRight": {
-  lucide: React.lazy(() => import("lucide-react").then(mod => ({
-    default: mod.ArrowRight
-  }))),
-  radix: React.lazy(() => import("@radix-ui/react-icons").then(mod => ({
-    default: mod.ArrowRightIcon
-  }))),
-},  "ArrowUpDown": {
-  lucide: React.lazy(() => import("lucide-react").then(mod => ({
-    default: mod.ArrowUpDown
-  }))),
-  radix: React.lazy(() => import("@radix-ui/react-icons").then(mod => ({
-    default: mod.CaretSortIcon
-  }))),
-},  "BellRing": {
-  lucide: React.lazy(() => import("lucide-react").then(mod => ({
-    default: mod.BellRing
-  }))),
-  radix: React.lazy(() => import("@radix-ui/react-icons").then(mod => ({
-    default: mod.BellIcon
-  }))),
-},  "Bold": {
-  lucide: React.lazy(() => import("lucide-react").then(mod => ({
-    default: mod.Bold
-  }))),
-  radix: React.lazy(() => import("@radix-ui/react-icons").then(mod => ({
-    default: mod.FontBoldIcon
-  }))),
-},  "Calculator": {
-  lucide: React.lazy(() => import("lucide-react").then(mod => ({
-    default: mod.Calculator
-  }))),
-  radix: React.lazy(() => import("@radix-ui/react-icons").then(mod => ({
-    default: mod.ComponentPlaceholderIcon
-  }))),
-},  "Calendar": {
-  lucide: React.lazy(() => import("lucide-react").then(mod => ({
-    default: mod.Calendar
-  }))),
-  radix: React.lazy(() => import("@radix-ui/react-icons").then(mod => ({
-    default: mod.CalendarIcon
-  }))),
-},  "Check": {
-  lucide: React.lazy(() => import("lucide-react").then(mod => ({
-    default: mod.Check
-  }))),
-  radix: React.lazy(() => import("@radix-ui/react-icons").then(mod => ({
-    default: mod.CheckIcon
-  }))),
-},  "ChevronDown": {
-  lucide: React.lazy(() => import("lucide-react").then(mod => ({
-    default: mod.ChevronDown
-  }))),
-  radix: React.lazy(() => import("@radix-ui/react-icons").then(mod => ({
-    default: mod.ChevronDownIcon
-  }))),
-},  "ChevronLeft": {
-  lucide: React.lazy(() => import("lucide-react").then(mod => ({
-    default: mod.ChevronLeft
-  }))),
-  radix: React.lazy(() => import("@radix-ui/react-icons").then(mod => ({
-    default: mod.ChevronLeftIcon
-  }))),
-},  "ChevronRight": {
-  lucide: React.lazy(() => import("lucide-react").then(mod => ({
-    default: mod.ChevronRight
-  }))),
-  radix: React.lazy(() => import("@radix-ui/react-icons").then(mod => ({
-    default: mod.ChevronRightIcon
-  }))),
-},  "ChevronUp": {
-  lucide: React.lazy(() => import("lucide-react").then(mod => ({
-    default: mod.ChevronUp
-  }))),
-  radix: React.lazy(() => import("@radix-ui/react-icons").then(mod => ({
-    default: mod.ChevronUpIcon
-  }))),
-},  "ChevronsUpDown": {
-  lucide: React.lazy(() => import("lucide-react").then(mod => ({
-    default: mod.ChevronsUpDown
-  }))),
-  radix: React.lazy(() => import("@radix-ui/react-icons").then(mod => ({
-    default: mod.CaretSortIcon
-  }))),
-},  "Circle": {
-  lucide: React.lazy(() => import("lucide-react").then(mod => ({
-    default: mod.Circle
-  }))),
-  radix: React.lazy(() => import("@radix-ui/react-icons").then(mod => ({
-    default: mod.DotFilledIcon
-  }))),
-},  "Copy": {
-  lucide: React.lazy(() => import("lucide-react").then(mod => ({
-    default: mod.Copy
-  }))),
-  radix: React.lazy(() => import("@radix-ui/react-icons").then(mod => ({
-    default: mod.CopyIcon
-  }))),
-},  "CreditCard": {
-  lucide: React.lazy(() => import("lucide-react").then(mod => ({
-    default: mod.CreditCard
-  }))),
-  radix: React.lazy(() => import("@radix-ui/react-icons").then(mod => ({
-    default: mod.ComponentPlaceholderIcon
-  }))),
-},  "GripVertical": {
-  lucide: React.lazy(() => import("lucide-react").then(mod => ({
-    default: mod.GripVertical
-  }))),
-  radix: React.lazy(() => import("@radix-ui/react-icons").then(mod => ({
-    default: mod.DragHandleDots2Icon
-  }))),
-},  "Italic": {
-  lucide: React.lazy(() => import("lucide-react").then(mod => ({
-    default: mod.Italic
-  }))),
-  radix: React.lazy(() => import("@radix-ui/react-icons").then(mod => ({
-    default: mod.FontItalicIcon
-  }))),
-},  "Loader2": {
-  lucide: React.lazy(() => import("lucide-react").then(mod => ({
-    default: mod.Loader2
-  }))),
-  radix: React.lazy(() => import("@radix-ui/react-icons").then(mod => ({
-    default: mod.ReloadIcon
-  }))),
-},  "Mail": {
-  lucide: React.lazy(() => import("lucide-react").then(mod => ({
-    default: mod.Mail
-  }))),
-  radix: React.lazy(() => import("@radix-ui/react-icons").then(mod => ({
-    default: mod.EnvelopeClosedIcon
-  }))),
-},  "MailOpen": {
-  lucide: React.lazy(() => import("lucide-react").then(mod => ({
-    default: mod.MailOpen
-  }))),
-  radix: React.lazy(() => import("@radix-ui/react-icons").then(mod => ({
-    default: mod.EnvelopeOpenIcon
-  }))),
-},  "Minus": {
-  lucide: React.lazy(() => import("lucide-react").then(mod => ({
-    default: mod.Minus
-  }))),
-  radix: React.lazy(() => import("@radix-ui/react-icons").then(mod => ({
-    default: mod.MinusIcon
-  }))),
-},  "Moon": {
-  lucide: React.lazy(() => import("lucide-react").then(mod => ({
-    default: mod.Moon
-  }))),
-  radix: React.lazy(() => import("@radix-ui/react-icons").then(mod => ({
-    default: mod.MoonIcon
-  }))),
-},  "MoreHorizontal": {
-  lucide: React.lazy(() => import("lucide-react").then(mod => ({
-    default: mod.MoreHorizontal
-  }))),
-  radix: React.lazy(() => import("@radix-ui/react-icons").then(mod => ({
-    default: mod.DotsHorizontalIcon
-  }))),
-},  "PanelLeft": {
-  lucide: React.lazy(() => import("lucide-react").then(mod => ({
-    default: mod.PanelLeft
-  }))),
-  radix: React.lazy(() => import("@radix-ui/react-icons").then(mod => ({
-    default: mod.ViewVerticalIcon
-  }))),
-},  "Plus": {
-  lucide: React.lazy(() => import("lucide-react").then(mod => ({
-    default: mod.Plus
-  }))),
-  radix: React.lazy(() => import("@radix-ui/react-icons").then(mod => ({
-    default: mod.PlusIcon
-  }))),
-},  "Search": {
-  lucide: React.lazy(() => import("lucide-react").then(mod => ({
-    default: mod.Search
-  }))),
-  radix: React.lazy(() => import("@radix-ui/react-icons").then(mod => ({
-    default: mod.MagnifyingGlassIcon
-  }))),
-},  "Send": {
-  lucide: React.lazy(() => import("lucide-react").then(mod => ({
-    default: mod.Send
-  }))),
-  radix: React.lazy(() => import("@radix-ui/react-icons").then(mod => ({
-    default: mod.PaperPlaneIcon
-  }))),
-},  "Settings": {
-  lucide: React.lazy(() => import("lucide-react").then(mod => ({
-    default: mod.Settings
-  }))),
-  radix: React.lazy(() => import("@radix-ui/react-icons").then(mod => ({
-    default: mod.GearIcon
-  }))),
-},  "Slash": {
-  lucide: React.lazy(() => import("lucide-react").then(mod => ({
-    default: mod.Slash
-  }))),
-  radix: React.lazy(() => import("@radix-ui/react-icons").then(mod => ({
-    default: mod.SlashIcon
-  }))),
-},  "Smile": {
-  lucide: React.lazy(() => import("lucide-react").then(mod => ({
-    default: mod.Smile
-  }))),
-  radix: React.lazy(() => import("@radix-ui/react-icons").then(mod => ({
-    default: mod.FaceIcon
-  }))),
-},  "Sun": {
-  lucide: React.lazy(() => import("lucide-react").then(mod => ({
-    default: mod.Sun
-  }))),
-  radix: React.lazy(() => import("@radix-ui/react-icons").then(mod => ({
-    default: mod.SunIcon
-  }))),
-},  "Terminal": {
-  lucide: React.lazy(() => import("lucide-react").then(mod => ({
-    default: mod.Terminal
-  }))),
-  radix: React.lazy(() => import("@radix-ui/react-icons").then(mod => ({
-    default: mod.RocketIcon
-  }))),
-},  "Underline": {
-  lucide: React.lazy(() => import("lucide-react").then(mod => ({
-    default: mod.Underline
-  }))),
-  radix: React.lazy(() => import("@radix-ui/react-icons").then(mod => ({
-    default: mod.UnderlineIcon
-  }))),
-},  "User": {
-  lucide: React.lazy(() => import("lucide-react").then(mod => ({
-    default: mod.User
-  }))),
-  radix: React.lazy(() => import("@radix-ui/react-icons").then(mod => ({
-    default: mod.PersonIcon
-  }))),
-},  "X": {
-  lucide: React.lazy(() => import("lucide-react").then(mod => ({
-    default: mod.X
-  }))),
-  radix: React.lazy(() => import("@radix-ui/react-icons").then(mod => ({
-    default: mod.Cross2Icon
-  }))),
-},
+  AlertCircle: {
+    lucide: React.lazy(() =>
+      import("lucide-react").then((mod) => ({
+        default: mod.AlertCircle,
+      }))
+    ),
+    radix: React.lazy(() =>
+      import("@radix-ui/react-icons").then((mod) => ({
+        default: mod.ExclamationTriangleIcon,
+      }))
+    ),
+  },
+  ArrowLeft: {
+    lucide: React.lazy(() =>
+      import("lucide-react").then((mod) => ({
+        default: mod.ArrowLeft,
+      }))
+    ),
+    radix: React.lazy(() =>
+      import("@radix-ui/react-icons").then((mod) => ({
+        default: mod.ArrowLeftIcon,
+      }))
+    ),
+  },
+  ArrowRight: {
+    lucide: React.lazy(() =>
+      import("lucide-react").then((mod) => ({
+        default: mod.ArrowRight,
+      }))
+    ),
+    radix: React.lazy(() =>
+      import("@radix-ui/react-icons").then((mod) => ({
+        default: mod.ArrowRightIcon,
+      }))
+    ),
+  },
+  ArrowUpDown: {
+    lucide: React.lazy(() =>
+      import("lucide-react").then((mod) => ({
+        default: mod.ArrowUpDown,
+      }))
+    ),
+    radix: React.lazy(() =>
+      import("@radix-ui/react-icons").then((mod) => ({
+        default: mod.CaretSortIcon,
+      }))
+    ),
+  },
+  BellRing: {
+    lucide: React.lazy(() =>
+      import("lucide-react").then((mod) => ({
+        default: mod.BellRing,
+      }))
+    ),
+    radix: React.lazy(() =>
+      import("@radix-ui/react-icons").then((mod) => ({
+        default: mod.BellIcon,
+      }))
+    ),
+  },
+  Bold: {
+    lucide: React.lazy(() =>
+      import("lucide-react").then((mod) => ({
+        default: mod.Bold,
+      }))
+    ),
+    radix: React.lazy(() =>
+      import("@radix-ui/react-icons").then((mod) => ({
+        default: mod.FontBoldIcon,
+      }))
+    ),
+  },
+  Calculator: {
+    lucide: React.lazy(() =>
+      import("lucide-react").then((mod) => ({
+        default: mod.Calculator,
+      }))
+    ),
+    radix: React.lazy(() =>
+      import("@radix-ui/react-icons").then((mod) => ({
+        default: mod.ComponentPlaceholderIcon,
+      }))
+    ),
+  },
+  Calendar: {
+    lucide: React.lazy(() =>
+      import("lucide-react").then((mod) => ({
+        default: mod.Calendar,
+      }))
+    ),
+    radix: React.lazy(() =>
+      import("@radix-ui/react-icons").then((mod) => ({
+        default: mod.CalendarIcon,
+      }))
+    ),
+  },
+  Check: {
+    lucide: React.lazy(() =>
+      import("lucide-react").then((mod) => ({
+        default: mod.Check,
+      }))
+    ),
+    radix: React.lazy(() =>
+      import("@radix-ui/react-icons").then((mod) => ({
+        default: mod.CheckIcon,
+      }))
+    ),
+  },
+  ChevronDown: {
+    lucide: React.lazy(() =>
+      import("lucide-react").then((mod) => ({
+        default: mod.ChevronDown,
+      }))
+    ),
+    radix: React.lazy(() =>
+      import("@radix-ui/react-icons").then((mod) => ({
+        default: mod.ChevronDownIcon,
+      }))
+    ),
+  },
+  ChevronLeft: {
+    lucide: React.lazy(() =>
+      import("lucide-react").then((mod) => ({
+        default: mod.ChevronLeft,
+      }))
+    ),
+    radix: React.lazy(() =>
+      import("@radix-ui/react-icons").then((mod) => ({
+        default: mod.ChevronLeftIcon,
+      }))
+    ),
+  },
+  ChevronRight: {
+    lucide: React.lazy(() =>
+      import("lucide-react").then((mod) => ({
+        default: mod.ChevronRight,
+      }))
+    ),
+    radix: React.lazy(() =>
+      import("@radix-ui/react-icons").then((mod) => ({
+        default: mod.ChevronRightIcon,
+      }))
+    ),
+  },
+  ChevronUp: {
+    lucide: React.lazy(() =>
+      import("lucide-react").then((mod) => ({
+        default: mod.ChevronUp,
+      }))
+    ),
+    radix: React.lazy(() =>
+      import("@radix-ui/react-icons").then((mod) => ({
+        default: mod.ChevronUpIcon,
+      }))
+    ),
+  },
+  ChevronsUpDown: {
+    lucide: React.lazy(() =>
+      import("lucide-react").then((mod) => ({
+        default: mod.ChevronsUpDown,
+      }))
+    ),
+    radix: React.lazy(() =>
+      import("@radix-ui/react-icons").then((mod) => ({
+        default: mod.CaretSortIcon,
+      }))
+    ),
+  },
+  Circle: {
+    lucide: React.lazy(() =>
+      import("lucide-react").then((mod) => ({
+        default: mod.Circle,
+      }))
+    ),
+    radix: React.lazy(() =>
+      import("@radix-ui/react-icons").then((mod) => ({
+        default: mod.DotFilledIcon,
+      }))
+    ),
+  },
+  Copy: {
+    lucide: React.lazy(() =>
+      import("lucide-react").then((mod) => ({
+        default: mod.Copy,
+      }))
+    ),
+    radix: React.lazy(() =>
+      import("@radix-ui/react-icons").then((mod) => ({
+        default: mod.CopyIcon,
+      }))
+    ),
+  },
+  CreditCard: {
+    lucide: React.lazy(() =>
+      import("lucide-react").then((mod) => ({
+        default: mod.CreditCard,
+      }))
+    ),
+    radix: React.lazy(() =>
+      import("@radix-ui/react-icons").then((mod) => ({
+        default: mod.ComponentPlaceholderIcon,
+      }))
+    ),
+  },
+  GripVertical: {
+    lucide: React.lazy(() =>
+      import("lucide-react").then((mod) => ({
+        default: mod.GripVertical,
+      }))
+    ),
+    radix: React.lazy(() =>
+      import("@radix-ui/react-icons").then((mod) => ({
+        default: mod.DragHandleDots2Icon,
+      }))
+    ),
+  },
+  Italic: {
+    lucide: React.lazy(() =>
+      import("lucide-react").then((mod) => ({
+        default: mod.Italic,
+      }))
+    ),
+    radix: React.lazy(() =>
+      import("@radix-ui/react-icons").then((mod) => ({
+        default: mod.FontItalicIcon,
+      }))
+    ),
+  },
+  Loader2: {
+    lucide: React.lazy(() =>
+      import("lucide-react").then((mod) => ({
+        default: mod.Loader2,
+      }))
+    ),
+    radix: React.lazy(() =>
+      import("@radix-ui/react-icons").then((mod) => ({
+        default: mod.ReloadIcon,
+      }))
+    ),
+  },
+  Mail: {
+    lucide: React.lazy(() =>
+      import("lucide-react").then((mod) => ({
+        default: mod.Mail,
+      }))
+    ),
+    radix: React.lazy(() =>
+      import("@radix-ui/react-icons").then((mod) => ({
+        default: mod.EnvelopeClosedIcon,
+      }))
+    ),
+  },
+  MailOpen: {
+    lucide: React.lazy(() =>
+      import("lucide-react").then((mod) => ({
+        default: mod.MailOpen,
+      }))
+    ),
+    radix: React.lazy(() =>
+      import("@radix-ui/react-icons").then((mod) => ({
+        default: mod.EnvelopeOpenIcon,
+      }))
+    ),
+  },
+  Minus: {
+    lucide: React.lazy(() =>
+      import("lucide-react").then((mod) => ({
+        default: mod.Minus,
+      }))
+    ),
+    radix: React.lazy(() =>
+      import("@radix-ui/react-icons").then((mod) => ({
+        default: mod.MinusIcon,
+      }))
+    ),
+  },
+  Moon: {
+    lucide: React.lazy(() =>
+      import("lucide-react").then((mod) => ({
+        default: mod.Moon,
+      }))
+    ),
+    radix: React.lazy(() =>
+      import("@radix-ui/react-icons").then((mod) => ({
+        default: mod.MoonIcon,
+      }))
+    ),
+  },
+  MoreHorizontal: {
+    lucide: React.lazy(() =>
+      import("lucide-react").then((mod) => ({
+        default: mod.MoreHorizontal,
+      }))
+    ),
+    radix: React.lazy(() =>
+      import("@radix-ui/react-icons").then((mod) => ({
+        default: mod.DotsHorizontalIcon,
+      }))
+    ),
+  },
+  PanelLeft: {
+    lucide: React.lazy(() =>
+      import("lucide-react").then((mod) => ({
+        default: mod.PanelLeft,
+      }))
+    ),
+    radix: React.lazy(() =>
+      import("@radix-ui/react-icons").then((mod) => ({
+        default: mod.ViewVerticalIcon,
+      }))
+    ),
+  },
+  Plus: {
+    lucide: React.lazy(() =>
+      import("lucide-react").then((mod) => ({
+        default: mod.Plus,
+      }))
+    ),
+    radix: React.lazy(() =>
+      import("@radix-ui/react-icons").then((mod) => ({
+        default: mod.PlusIcon,
+      }))
+    ),
+  },
+  Search: {
+    lucide: React.lazy(() =>
+      import("lucide-react").then((mod) => ({
+        default: mod.Search,
+      }))
+    ),
+    radix: React.lazy(() =>
+      import("@radix-ui/react-icons").then((mod) => ({
+        default: mod.MagnifyingGlassIcon,
+      }))
+    ),
+  },
+  Send: {
+    lucide: React.lazy(() =>
+      import("lucide-react").then((mod) => ({
+        default: mod.Send,
+      }))
+    ),
+    radix: React.lazy(() =>
+      import("@radix-ui/react-icons").then((mod) => ({
+        default: mod.PaperPlaneIcon,
+      }))
+    ),
+  },
+  Settings: {
+    lucide: React.lazy(() =>
+      import("lucide-react").then((mod) => ({
+        default: mod.Settings,
+      }))
+    ),
+    radix: React.lazy(() =>
+      import("@radix-ui/react-icons").then((mod) => ({
+        default: mod.GearIcon,
+      }))
+    ),
+  },
+  Slash: {
+    lucide: React.lazy(() =>
+      import("lucide-react").then((mod) => ({
+        default: mod.Slash,
+      }))
+    ),
+    radix: React.lazy(() =>
+      import("@radix-ui/react-icons").then((mod) => ({
+        default: mod.SlashIcon,
+      }))
+    ),
+  },
+  Smile: {
+    lucide: React.lazy(() =>
+      import("lucide-react").then((mod) => ({
+        default: mod.Smile,
+      }))
+    ),
+    radix: React.lazy(() =>
+      import("@radix-ui/react-icons").then((mod) => ({
+        default: mod.FaceIcon,
+      }))
+    ),
+  },
+  Sun: {
+    lucide: React.lazy(() =>
+      import("lucide-react").then((mod) => ({
+        default: mod.Sun,
+      }))
+    ),
+    radix: React.lazy(() =>
+      import("@radix-ui/react-icons").then((mod) => ({
+        default: mod.SunIcon,
+      }))
+    ),
+  },
+  Terminal: {
+    lucide: React.lazy(() =>
+      import("lucide-react").then((mod) => ({
+        default: mod.Terminal,
+      }))
+    ),
+    radix: React.lazy(() =>
+      import("@radix-ui/react-icons").then((mod) => ({
+        default: mod.RocketIcon,
+      }))
+    ),
+  },
+  Underline: {
+    lucide: React.lazy(() =>
+      import("lucide-react").then((mod) => ({
+        default: mod.Underline,
+      }))
+    ),
+    radix: React.lazy(() =>
+      import("@radix-ui/react-icons").then((mod) => ({
+        default: mod.UnderlineIcon,
+      }))
+    ),
+  },
+  User: {
+    lucide: React.lazy(() =>
+      import("lucide-react").then((mod) => ({
+        default: mod.User,
+      }))
+    ),
+    radix: React.lazy(() =>
+      import("@radix-ui/react-icons").then((mod) => ({
+        default: mod.PersonIcon,
+      }))
+    ),
+  },
+  X: {
+    lucide: React.lazy(() =>
+      import("lucide-react").then((mod) => ({
+        default: mod.X,
+      }))
+    ),
+    radix: React.lazy(() =>
+      import("@radix-ui/react-icons").then((mod) => ({
+        default: mod.Cross2Icon,
+      }))
+    ),
+  },
 }

--- a/packages/kodkafa/src/utils/transformers/index.ts
+++ b/packages/kodkafa/src/utils/transformers/index.ts
@@ -64,5 +64,4 @@ export async function transform(
   }
 
   return sourceFile.getText().replace(/\/reform\/re-form"/g, '/re-form"')
-
 }

--- a/packages/kodkafa/src/utils/transformers/index.ts
+++ b/packages/kodkafa/src/utils/transformers/index.ts
@@ -63,5 +63,6 @@ export async function transform(
     })
   }
 
-  return sourceFile.getText()
+  return sourceFile.getText().replace(/\/reform\/re-form"/g, '/re-form"')
+
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -383,97 +383,6 @@ importers:
         specifier: ^4.1.2
         version: 4.1.2
 
-  packages/cli:
-    dependencies:
-      '@antfu/ni':
-        specifier: ^0.21.4
-        version: 0.21.4
-      '@babel/core':
-        specifier: ^7.22.1
-        version: 7.22.1
-      '@babel/parser':
-        specifier: ^7.22.6
-        version: 7.22.6
-      '@babel/plugin-transform-typescript':
-        specifier: ^7.22.5
-        version: 7.22.5(@babel/core@7.22.1)
-      chalk:
-        specifier: 5.2.0
-        version: 5.2.0
-      commander:
-        specifier: ^10.0.0
-        version: 10.0.0
-      cosmiconfig:
-        specifier: ^8.1.3
-        version: 8.1.3
-      diff:
-        specifier: ^5.1.0
-        version: 5.1.0
-      execa:
-        specifier: ^7.0.0
-        version: 7.0.0
-      fast-glob:
-        specifier: ^3.3.2
-        version: 3.3.2
-      fs-extra:
-        specifier: ^11.1.0
-        version: 11.1.0
-      https-proxy-agent:
-        specifier: ^6.2.0
-        version: 6.2.0
-      lodash:
-        specifier: ^4.17.21
-        version: 4.17.21
-      node-fetch:
-        specifier: ^3.3.0
-        version: 3.3.0
-      ora:
-        specifier: ^6.1.2
-        version: 6.1.2
-      prompts:
-        specifier: ^2.4.2
-        version: 2.4.2
-      recast:
-        specifier: ^0.23.2
-        version: 0.23.2
-      ts-morph:
-        specifier: ^18.0.0
-        version: 18.0.0
-      tsconfig-paths:
-        specifier: ^4.2.0
-        version: 4.2.0
-      zod:
-        specifier: ^3.20.2
-        version: 3.21.4
-    devDependencies:
-      '@types/babel__core':
-        specifier: ^7.20.1
-        version: 7.20.1
-      '@types/diff':
-        specifier: ^5.0.3
-        version: 5.0.3
-      '@types/fs-extra':
-        specifier: ^11.0.1
-        version: 11.0.1
-      '@types/lodash':
-        specifier: ^4.17.7
-        version: 4.17.7
-      '@types/prompts':
-        specifier: ^2.4.2
-        version: 2.4.2
-      rimraf:
-        specifier: ^4.1.3
-        version: 4.1.3
-      tsup:
-        specifier: ^6.6.3
-        version: 6.6.3(postcss@8.4.41)(ts-node@10.9.2(@types/node@20.14.0)(typescript@4.9.5))(typescript@4.9.5)
-      type-fest:
-        specifier: ^3.8.0
-        version: 3.8.0
-      typescript:
-        specifier: ^4.9.3
-        version: 4.9.5
-
   packages/kodkafa:
     dependencies:
       '@antfu/ni':
@@ -3534,10 +3443,6 @@ packages:
       ts-node: '>=10'
       typescript: '>=4'
 
-  cosmiconfig@8.1.3:
-    resolution: {integrity: sha512-/UkO2JKI18b5jVMJUp0lvKFMpa/Gye+ZgZjKD+DGEN9y7NRcf/nK1A0sp67ONmKtnDCNMS44E6jrk0Yc3bDuUw==}
-    engines: {node: '>=14'}
-
   cosmiconfig@8.3.6:
     resolution: {integrity: sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==}
     engines: {node: '>=14'}
@@ -3790,10 +3695,6 @@ packages:
 
   diff@4.0.2:
     resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
-    engines: {node: '>=0.3.1'}
-
-  diff@5.1.0:
-    resolution: {integrity: sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==}
     engines: {node: '>=0.3.1'}
 
   diff@5.2.0:
@@ -4239,10 +4140,6 @@ packages:
 
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
-
-  fs-extra@11.1.0:
-    resolution: {integrity: sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==}
-    engines: {node: '>=14.14'}
 
   fs-extra@11.2.0:
     resolution: {integrity: sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==}
@@ -7375,19 +7272,6 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  '@babel/helper-create-class-features-plugin@7.24.6(@babel/core@7.22.1)':
-    dependencies:
-      '@babel/core': 7.22.1
-      '@babel/helper-annotate-as-pure': 7.24.6
-      '@babel/helper-environment-visitor': 7.24.6
-      '@babel/helper-function-name': 7.24.6
-      '@babel/helper-member-expression-to-functions': 7.24.6
-      '@babel/helper-optimise-call-expression': 7.24.6
-      '@babel/helper-replace-supers': 7.24.6(@babel/core@7.22.1)
-      '@babel/helper-skip-transparent-expression-wrappers': 7.24.6
-      '@babel/helper-split-export-declaration': 7.24.6
-      semver: 6.3.1
-
   '@babel/helper-create-class-features-plugin@7.24.6(@babel/core@7.24.6)':
     dependencies:
       '@babel/core': 7.24.6
@@ -7444,13 +7328,6 @@ snapshots:
 
   '@babel/helper-plugin-utils@7.24.6': {}
 
-  '@babel/helper-replace-supers@7.24.6(@babel/core@7.22.1)':
-    dependencies:
-      '@babel/core': 7.22.1
-      '@babel/helper-environment-visitor': 7.24.6
-      '@babel/helper-member-expression-to-functions': 7.24.6
-      '@babel/helper-optimise-call-expression': 7.24.6
-
   '@babel/helper-replace-supers@7.24.6(@babel/core@7.24.6)':
     dependencies:
       '@babel/core': 7.24.6
@@ -7496,23 +7373,10 @@ snapshots:
     dependencies:
       '@babel/types': 7.24.6
 
-  '@babel/plugin-syntax-typescript@7.24.6(@babel/core@7.22.1)':
-    dependencies:
-      '@babel/core': 7.22.1
-      '@babel/helper-plugin-utils': 7.24.6
-
   '@babel/plugin-syntax-typescript@7.24.6(@babel/core@7.24.6)':
     dependencies:
       '@babel/core': 7.24.6
       '@babel/helper-plugin-utils': 7.24.6
-
-  '@babel/plugin-transform-typescript@7.22.5(@babel/core@7.22.1)':
-    dependencies:
-      '@babel/core': 7.22.1
-      '@babel/helper-annotate-as-pure': 7.24.6
-      '@babel/helper-create-class-features-plugin': 7.24.6(@babel/core@7.22.1)
-      '@babel/helper-plugin-utils': 7.24.6
-      '@babel/plugin-syntax-typescript': 7.24.6(@babel/core@7.22.1)
 
   '@babel/plugin-transform-typescript@7.22.5(@babel/core@7.24.6)':
     dependencies:
@@ -10521,13 +10385,6 @@ snapshots:
       ts-node: 10.9.2(@types/node@20.5.1)(typescript@5.5.3)
       typescript: 5.5.3
 
-  cosmiconfig@8.1.3:
-    dependencies:
-      import-fresh: 3.3.0
-      js-yaml: 4.1.0
-      parse-json: 5.2.0
-      path-type: 4.0.0
-
   cosmiconfig@8.3.6(typescript@4.9.5):
     dependencies:
       import-fresh: 3.3.0
@@ -10754,8 +10611,6 @@ snapshots:
   didyoumean@1.2.2: {}
 
   diff@4.0.2: {}
-
-  diff@5.1.0: {}
 
   diff@5.2.0: {}
 
@@ -11058,7 +10913,7 @@ snapshots:
       debug: 4.3.5
       enhanced-resolve: 5.16.1
       eslint: 8.44.0
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@5.61.0(eslint@8.44.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.44.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@5.61.0(eslint@8.44.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.61.0(eslint@8.44.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.44.0))(eslint@8.44.0)
       eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.61.0(eslint@8.44.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.44.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.5
@@ -11070,7 +10925,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@5.61.0(eslint@8.44.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.44.0):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@5.61.0(eslint@8.44.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.61.0(eslint@8.44.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.44.0))(eslint@8.44.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -11091,7 +10946,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.44.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@5.61.0(eslint@8.44.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.44.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@5.61.0(eslint@8.44.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.61.0(eslint@8.44.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.44.0))(eslint@8.44.0)
       hasown: 2.0.2
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -11434,12 +11289,6 @@ snapshots:
       react-dom: 18.2.0(react@18.2.0)
 
   fs-constants@1.0.0: {}
-
-  fs-extra@11.1.0:
-    dependencies:
-      graceful-fs: 4.2.11
-      jsonfile: 6.1.0
-      universalify: 2.0.1
 
   fs-extra@11.2.0:
     dependencies:


### PR DESCRIPTION
The easiest way to fix "Cannot find module '.../reform/re-form'" bug, while keeping the current version running, is to use some Regex Magic.